### PR TITLE
Update to latest WORLD, allow changing all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,18 @@ and the [official website of World Vocoder](http://ml.cs.yamanashi.ac.jp/world/e
 ### Vocoder Functions
 ```python
 import pyworld as pw
-pyDioOpt = pw.pyDioOption()
 _f0, t = pw.dio(x, fs)    # raw pitch extractor
 f0 = pw.stonemask(x, _f0, t, fs)  # pitch refinement
 sp = pw.cheaptrick(x, f0, t, fs)  # extract smoothed spectrogram
 ap = pw.d4c(x, f0, t, fs)         # extract aperiodicity
-y = pw.synthesize(f0, sp, ap, fs, pyDioOpt.option['frame_period'])
+y = pw.synthesize(f0, sp, ap, fs)
 ```
 
 
 ### Utility
 ```python
 # Convert speech into features (using default options)
-f0, sp, ap, pyDioOpt = pw.wav2world(x, fs)
+f0, sp, ap = pw.wav2world(x, fs)
 ```
 
 

--- a/demo.py
+++ b/demo.py
@@ -16,7 +16,7 @@ import pyworld as pw
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-r", "--frame_rate", type=int, default=5)
+parser.add_argument("-f", "--frame_period", type=float, default=5.0)
 parser.add_argument("-s", "--speed", type=int, default=1)
 
 
@@ -69,7 +69,7 @@ def main(args):
         f0_floor=50,
         f0_ceil=600,
         channels_in_octave=2,
-        frame_period=args.frame_rate,
+        frame_period=args.frame_period,
         speed=args.speed)
 
     # 2-1 DIO without F0 refinement

--- a/demo.py
+++ b/demo.py
@@ -61,22 +61,18 @@ def main(args):
     # x, fs = librosa.load('utterance/vaiueo2d.wav', dtype=np.float64)
 
     # 1. A convient way
-    f0, sp, ap, pyDioOpt = pw.wav2world(x, fs)    # use default options
-    y = pw.synthesize(f0, sp, ap, fs, pyDioOpt.option['frame_period'])
+    f0, sp, ap = pw.wav2world(x, fs)    # use default options
+    y = pw.synthesize(f0, sp, ap, fs, pw.default_frame_period)
 
     # 2. Step by step
-    pyDioOpt = pw.pyDioOption(
-        f0_floor=50,
-        f0_ceil=600,
-        channels_in_octave=2,
-        frame_period=args.frame_period,
-        speed=args.speed)
-
-    # 2-1 DIO without F0 refinement
-    _f0, t = pw.dio(x, fs, pyDioOpt)
+    # 2-1 Without F0 refinement
+    _f0, t = pw.dio(x, fs, f0_floor=50.0, f0_ceil=600.0,
+                    channels_in_octave=2,
+                    frame_period=args.frame_period,
+                    speed=args.speed)
     _sp = pw.cheaptrick(x, _f0, t, fs)
     _ap = pw.d4c(x, _f0, t, fs)
-    _y = pw.synthesize(_f0, _sp, _ap, fs, pyDioOpt.option['frame_period'])
+    _y = pw.synthesize(_f0, _sp, _ap, fs, args.frame_period)
     # librosa.output.write_wav('test/y_without_f0_refinement.wav', _y, fs)
     sf.write('test/y_without_f0_refinement.wav', _y, fs)
 
@@ -84,7 +80,7 @@ def main(args):
     f0 = pw.stonemask(x, _f0, t, fs)
     sp = pw.cheaptrick(x, f0, t, fs)
     ap = pw.d4c(x, f0, t, fs)
-    y = pw.synthesize(f0, sp, ap, fs, pyDioOpt.option['frame_period'])
+    y = pw.synthesize(f0, sp, ap, fs, args.frame_period)
     # librosa.output.write_wav('test/y_with_f0_refinement.wav', y, fs)
     sf.write('test/y_with_f0_refinement.wav', y, fs)
 
@@ -93,7 +89,7 @@ def main(args):
     f0_h = pw.stonemask(x, _f0_h, t_h, fs)
     sp_h = pw.cheaptrick(x, f0_h, t_h, fs)
     ap_h = pw.d4c(x, f0_h, t_h, fs)
-    y_h = pw.synthesize(f0_h, sp_h, ap_h, fs, 5.0)
+    y_h = pw.synthesize(f0_h, sp_h, ap_h, fs, pw.default_frame_period)
     # librosa.output.write_wav('test/y_harvest_with_f0_refinement.wav', y_h, fs)
     sf.write('test/y_harvest_with_f0_refinement.wav', y_h, fs)
 

--- a/demo.py
+++ b/demo.py
@@ -72,7 +72,7 @@ def main(args):
         frame_period=args.frame_rate,
         speed=args.speed)
 
-    # 2-1 Without F0 refinement
+    # 2-1 DIO without F0 refinement
     _f0, t = pw.dio(x, fs, pyDioOpt)
     _sp = pw.cheaptrick(x, _f0, t, fs)
     _ap = pw.d4c(x, _f0, t, fs)
@@ -80,14 +80,22 @@ def main(args):
     # librosa.output.write_wav('test/y_without_f0_refinement.wav', _y, fs)
     sf.write('test/y_without_f0_refinement.wav', _y, fs)
 
-
-    # 2-2 With F0 refinement (using stonemask)
+    # 2-2 DIO with F0 refinement (using Stonemask)
     f0 = pw.stonemask(x, _f0, t, fs)
     sp = pw.cheaptrick(x, f0, t, fs)
     ap = pw.d4c(x, f0, t, fs)
     y = pw.synthesize(f0, sp, ap, fs, pyDioOpt.option['frame_period'])
     # librosa.output.write_wav('test/y_with_f0_refinement.wav', y, fs)
     sf.write('test/y_with_f0_refinement.wav', y, fs)
+
+    # 2-3 Harvest with F0 refinement (using Stonemask)
+    _f0_h, t_h = pw.harvest(x, fs)
+    f0_h = pw.stonemask(x, _f0_h, t_h, fs)
+    sp_h = pw.cheaptrick(x, f0_h, t_h, fs)
+    ap_h = pw.d4c(x, f0_h, t_h, fs)
+    y_h = pw.synthesize(f0_h, sp_h, ap_h, fs, 5.0)
+    # librosa.output.write_wav('test/y_harvest_with_f0_refinement.wav', y_h, fs)
+    sf.write('test/y_harvest_with_f0_refinement.wav', y_h, fs)
 
     # Comparison
     savefig('test/wavform.png', [x, _y, y])

--- a/pyworld.pyx
+++ b/pyworld.pyx
@@ -6,13 +6,11 @@ import numpy as np
 cimport numpy as np
 np.import_array()
 
-# Notice: wavread and wavwrite is removed form world.
-# [TODO] It seems that I can't specify fft_size from outside?
 
 cdef extern from "src/world/synthesis.h":
     void Synthesis(const double *f0, 
-        int f0_length, double** spectrogram, 
-        double** aperiodicity, 
+        int f0_length, const double * const *spectrogram,
+        const double * const *aperiodicity, 
         int fft_size, double frame_period, 
         int fs, int y_length, double *y)
 
@@ -21,10 +19,11 @@ cdef extern from "src/world/cheaptrick.h":
     ctypedef struct CheapTrickOption:
         double q1
         double f0_floor
+        int fft_size
 
     int GetFFTSizeForCheapTrick(int fs, const CheapTrickOption *option)
     void InitializeCheapTrickOption(int fs, CheapTrickOption *option)
-    void CheapTrick(const double *x, int x_length, int fs, const double *time_axis,
+    void CheapTrick(const double *x, int x_length, int fs, const double *temporal_positions,
         const double *f0, int f0_length, const CheapTrickOption *option,
         double **spectrogram)
 
@@ -38,26 +37,25 @@ cdef extern from "src/world/dio.h":
         int speed
         double allowed_range
 
-    void InitializeDioOption(DioOption *option)
-    
+    void InitializeDioOption(DioOption *option)    
     int GetSamplesForDIO(int fs, int x_length, double frame_period)
     void Dio(const double *x, int x_length, int fs, const DioOption *option,
-        double *time_axis, double *f0)
+        double *temporal_positions, double *f0)
 
 
 cdef extern from "src/world/d4c.h":
     ctypedef struct D4COption:
-        double dummy
+        double threshold
     
     void InitializeD4COption(D4COption *option)
-    void D4C(const double *x, int x_length, int fs, const double *time_axis,
+    void D4C(const double *x, int x_length, int fs, const double *temporal_positions,
         const double *f0, int f0_length, int fft_size, const D4COption *option,
         double **aperiodicity) 
 
 
 cdef extern from "src/world/stonemask.h":
     void StoneMask(const double *x, int x_length, int fs, 
-        const double *time_axis, const double *f0, int f0_length, 
+        const double *temporal_positions, const double *f0, int f0_length, 
         double *refined_f0)
 
 
@@ -80,28 +78,28 @@ def dio(
     int fs, 
     pyDioOpt):
     ''' Raw Pitch (F0) extractor '''
-    x_length = len(x)
+    cdef int x_length = <int>len(x)
     cdef DioOption dioOption = pyDioOpt.option
     f0_length = GetSamplesForDIO(fs, x_length, dioOption.frame_period)
     cdef np.ndarray[double, ndim=1, mode="c"] f0 = \
         np.zeros(f0_length, dtype = np.dtype('float64'))
-    cdef np.ndarray[double, ndim=1, mode="c"] time_axis = \
+    cdef np.ndarray[double, ndim=1, mode="c"] temporal_positions = \
         np.zeros(f0_length, dtype = np.dtype('float64'))
-    Dio(&x[0], x_length, fs, &dioOption, &time_axis[0], &f0[0])
-    return f0, time_axis
+    Dio(&x[0], x_length, fs, &dioOption, &temporal_positions[0], &f0[0])
+    return f0, temporal_positions
 
 
 def stonemask(
     np.ndarray[double, ndim=1, mode="c"] x not None, 
     np.ndarray[double, ndim=1, mode="c"] f0 not None, 
-    np.ndarray[double, ndim=1, mode="c"] time_axis not None, 
+    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None, 
     int fs):
     ''' Pitch (F0) refinement '''
-    cdef int x_length = len(x)
-    cdef int f0_length = len(f0)
+    cdef int x_length = <int>len(x)
+    cdef int f0_length = <int>len(f0)
     cdef np.ndarray[double, ndim=1, mode="c"] refined_f0 = \
         np.zeros(f0_length, dtype = np.dtype('float64'))
-    StoneMask(&x[0], x_length, fs, &time_axis[0],
+    StoneMask(&x[0], x_length, fs, &temporal_positions[0],
         &f0[0], f0_length, &refined_f0[0])
     return refined_f0
 
@@ -109,13 +107,13 @@ def stonemask(
 def cheaptrick(
     np.ndarray[double, ndim=1, mode="c"] x not None, 
     np.ndarray[double, ndim=1, mode="c"] f0 not None,
-    np.ndarray[double, ndim=1, mode="c"] time_axis not None,
+    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
     int fs):
     ''' STRAIGHT spectrum '''
     cdef CheapTrickOption option
     InitializeCheapTrickOption(fs, &option)
-    cdef int x_length = len(x)
-    cdef int f0_length = len(f0)
+    cdef int x_length = <int>len(x)
+    cdef int f0_length = <int>len(f0)
     cdef int fft_size = GetFFTSizeForCheapTrick(fs, &option)
 
     cdef double[:,::1] spectrogram = np.zeros((f0_length, fft_size/2+1))
@@ -125,7 +123,7 @@ def cheaptrick(
     for i in range(f0_length):
         cpp_spectrogram[i] = &spectrogram[i, 0]
 
-    CheapTrick(&x[0], x_length, fs, &time_axis[0],
+    CheapTrick(&x[0], x_length, fs, &temporal_positions[0],
         &f0[0], f0_length, &option, cpp_spectrogram)
     return np.array(spectrogram, dtype=np.float64)
 
@@ -133,11 +131,11 @@ def cheaptrick(
 def d4c(
     np.ndarray[double, ndim=1, mode="c"] x not None, 
     np.ndarray[double, ndim=1, mode="c"] f0 not None,
-    np.ndarray[double, ndim=1, mode="c"] time_axis not None,
+    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
     int fs):
     ''' Aperiodicity Estimation '''
-    cdef int x_length = len(x)
-    cdef int f0_length = len(f0)
+    cdef int x_length = <int>len(x)
+    cdef int f0_length = <int>len(f0)
     cdef CheapTrickOption opt
     InitializeCheapTrickOption(fs, &opt)
     cdef int fft_size = GetFFTSizeForCheapTrick(fs, &opt)
@@ -152,7 +150,7 @@ def d4c(
     for i in range(f0_length):
         cpp_aperiodicity[i] = &aperiodicity[i, 0]
 
-    D4C(&x[0], x_length, fs, &time_axis[0],
+    D4C(&x[0], x_length, fs, &temporal_positions[0],
         &f0[0], f0_length, fft_size, &option,
         cpp_aperiodicity) 
     return np.array(aperiodicity, dtype=np.float64)
@@ -165,10 +163,10 @@ def synthesize(
     int fs,
     double frame_period):
     ''' Synthesizer '''
-    cdef int f0_length = len(f0)
+    cdef int f0_length = <int>len(f0)
     y_length = int(f0_length * frame_period * fs / 1000)
     # cdef int fft_size = GetFFTSizeForCheapTrick(fs)
-    cdef int fft_size = (np_spectrogram.shape[1] - 1)*2
+    cdef int fft_size = (<int>np_spectrogram.shape[1] - 1)*2
     cdef np.ndarray[double, ndim=1, mode="c"] y = \
         np.zeros(y_length, dtype = np.dtype('float64'))
 

--- a/pyworld.pyx
+++ b/pyworld.pyx
@@ -37,7 +37,7 @@ cdef extern from "src/world/dio.h":
         int speed
         double allowed_range
 
-    void InitializeDioOption(DioOption *option)    
+    void InitializeDioOption(DioOption *option)
     int GetSamplesForDIO(int fs, int x_length, double frame_period)
     void Dio(const double *x, int x_length, int fs, const DioOption *option,
         double *temporal_positions, double *f0)
@@ -71,40 +71,98 @@ cdef extern from "src/world/stonemask.h":
         double *refined_f0)
 
 
-class pyDioOption:
-    ''' DioOption '''
-    def __init__(self, f0_floor=71, f0_ceil=800, 
-        channels_in_octave=2.0, frame_period=5, speed=1, allowed_range=0.1):
-        cdef DioOption option
-        InitializeDioOption(&option)
-        option.channels_in_octave = channels_in_octave
-        option.f0_floor = f0_floor
-        option.f0_ceil = f0_ceil
-        option.frame_period = frame_period
-        option.speed = speed
-        self.option = option
+default_frame_period = 5.0
+default_f0_floor = 71.0
+default_f0_ceil = 800.0
 
+def dio(np.ndarray[double, ndim=1, mode="c"] x not None, int fs, 
+        f0_floor=default_f0_floor, f0_ceil=default_f0_ceil, 
+        channels_in_octave=2.0, frame_period=default_frame_period, 
+        speed=1, allowed_range=0.1):
+    """DIO F0 extraction algorithm.
 
-def dio(
-    np.ndarray[double, ndim=1, mode="c"] x not None, 
-    int fs, 
-    pyDioOpt):
-    ''' Raw Pitch (F0) extractor '''
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    fs : int
+        Sample rate of input signal in Hz.
+    f0_floor : float
+        Lower F0 limit in Hz.
+        Default: 71.0
+    f0_ceil : float
+        Upper F0 limit in Hz.
+        Default: 800.0
+    channels_in_octave : float
+        Resolution of multiband processing; normally shouldn't be changed.
+        Default: 2.0
+    frame_period : float
+        Period between consecutive frames in milliseconds.
+        Default: 5.0
+    speed : int
+        The F0 estimator may downsample the input signal using this integer factor 
+        (range [1;12]). The algorithm will then operate on a signal at fs/speed Hz
+        to reduce computational complexity, but high values may negatively impact 
+        accuracy.
+        Default: 1 (no downsampling)
+    allowed_range : float
+        Threshold for voiced/unvoiced decision. Can be any value >= 0, but 0.02 to 0.2 
+        is a reasonable range. Lower values will cause more frames to be considered 
+        unvoiced (in the extreme case of `threshold=0`, almost all frames will be unvoiced).
+        Default: 0.1
+
+    Returns
+    -------
+    f0 : ndarray
+        Estimated F0 contour.
+    temporal_positions : ndarray
+        Temporal position of each frame.
+    """
     cdef int x_length = <int>len(x)
-    cdef DioOption dioOption = pyDioOpt.option
-    f0_length = GetSamplesForDIO(fs, x_length, dioOption.frame_period)
+    cdef DioOption option
+    InitializeDioOption(&option)
+    option.channels_in_octave = channels_in_octave
+    option.f0_floor = f0_floor
+    option.f0_ceil = f0_ceil
+    option.frame_period = frame_period
+    option.speed = speed
+    f0_length = GetSamplesForDIO(fs, x_length, option.frame_period)
     cdef np.ndarray[double, ndim=1, mode="c"] f0 = \
         np.zeros(f0_length, dtype = np.dtype('float64'))
     cdef np.ndarray[double, ndim=1, mode="c"] temporal_positions = \
         np.zeros(f0_length, dtype = np.dtype('float64'))
-    Dio(&x[0], x_length, fs, &dioOption, &temporal_positions[0], &f0[0])
+    Dio(&x[0], x_length, fs, &option, &temporal_positions[0], &f0[0])
     return f0, temporal_positions
 
 
-def harvest(
-    np.ndarray[double, ndim=1, mode="c"] x not None, 
-    int fs):
-    ''' Raw Pitch (F0) extractor '''
+def harvest(np.ndarray[double, ndim=1, mode="c"] x not None, int fs, 
+            f0_floor=default_f0_floor, f0_ceil=default_f0_ceil, 
+            frame_period=default_frame_period):
+    """Harvest F0 extraction algorithm.
+
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    fs : int
+        Sample rate of input signal in Hz.
+    f0_floor : float
+        Lower F0 limit in Hz.
+        Default: 71.0
+    f0_ceil : float
+        Upper F0 limit in Hz.
+        Default: 800.0
+    frame_period : float
+        Period between consecutive frames in milliseconds.
+        Default: 5.0
+
+    Returns
+    -------
+    f0 : ndarray
+        Estimated F0 contour.
+    temporal_positions : ndarray
+        Temporal position of each frame.
+    """
     cdef int x_length = <int>len(x)
     cdef HarvestOption option
     InitializeHarvestOption(&option)
@@ -117,12 +175,28 @@ def harvest(
     return f0, temporal_positions
     
     
-def stonemask(
-    np.ndarray[double, ndim=1, mode="c"] x not None, 
-    np.ndarray[double, ndim=1, mode="c"] f0 not None, 
-    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None, 
-    int fs):
-    ''' Pitch (F0) refinement '''
+def stonemask(np.ndarray[double, ndim=1, mode="c"] x not None, 
+              np.ndarray[double, ndim=1, mode="c"] f0 not None, 
+              np.ndarray[double, ndim=1, mode="c"] temporal_positions not None, 
+              int fs):
+    """StoneMask F0 refinement algorithm.
+
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    f0 : ndarray
+        Input F0 contour.
+    temporal_positions : ndarray
+        Temporal positions of each frame.
+    fs : int
+        Sample rate of input signal in Hz.
+
+    Returns
+    -------
+    refined_f0 : ndarray
+        Refined F0 contour.
+    """
     cdef int x_length = <int>len(x)
     cdef int f0_length = <int>len(f0)
     cdef np.ndarray[double, ndim=1, mode="c"] refined_f0 = \
@@ -132,19 +206,75 @@ def stonemask(
     return refined_f0
 
 
-def cheaptrick(
-    np.ndarray[double, ndim=1, mode="c"] x not None, 
-    np.ndarray[double, ndim=1, mode="c"] f0 not None,
-    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
-    int fs):
-    ''' STRAIGHT spectrum '''
+def get_cheaptrick_fft_size(fs, f0_floor=default_f0_floor):
+    """Calculate suitable FFT size for CheapTrick given F0 floor.
+
+    Parameters
+    ----------
+    fs : int
+        Sample rate of input signal in Hz.
+    f0_floor : float
+        Lower F0 limit in Hz. The required FFT size is a direct 
+        consequence of the F0 floor used.
+        Default: 71.0
+
+    Returns
+    -------
+    fft_size : int
+        Resulting FFT size.
+    """
+    cdef CheapTrickOption option
+    option.f0_floor = f0_floor
+    cdef int fft_size = GetFFTSizeForCheapTrick(fs, &option)
+    return fft_size
+
+def cheaptrick(np.ndarray[double, ndim=1, mode="c"] x not None, 
+               np.ndarray[double, ndim=1, mode="c"] f0 not None,
+               np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
+               int fs,
+	           q1=-0.15, f0_floor=default_f0_floor, fft_size=None):
+    """CheapTrick harmonic spectral envelope estimation algorithm.
+
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    f0 : ndarray
+        Input F0 contour.
+    temporal_positions : ndarray
+        Temporal positions of each frame.
+    fs : int
+        Sample rate of input signal in Hz.
+    q1 : float
+        Spectral recovery parameter.
+        Default: -0.15 (this value was tuned and normally does not need adjustment)
+    f0_floor : float, None
+        Lower F0 limit in Hz. Not used in case `fft_size` is specified.
+        Default: 71.0
+    fft_size : int, None
+        FFT size to be used. When `None` (default) is used, the FFT size is computed 
+        automatically as a function of the given input sample rate and F0 floor. 
+        When a specific FFT size is specified, the given `f0_floor` parameter is ignored.
+        Default: None
+
+    Returns
+    -------
+    spectrogram : ndarray
+        Spectral envelope.
+    """
     cdef CheapTrickOption option
     InitializeCheapTrickOption(fs, &option)
+    option.q1 = q1
+    if fft_size is None:
+        option.f0_floor = f0_floor  # CheapTrickOption.f0_floor is only used in GetFFTSizeForCheapTrick()
+        option.fft_size = GetFFTSizeForCheapTrick(fs, &option)
+    else:
+        option.fft_size = fft_size
+        # the f0_floor used by CheapTrick() will be re-compute from this given fft_size
     cdef int x_length = <int>len(x)
     cdef int f0_length = <int>len(f0)
-    cdef int fft_size = GetFFTSizeForCheapTrick(fs, &option)
 
-    cdef double[:,::1] spectrogram = np.zeros((f0_length, fft_size/2+1))
+    cdef double[:,::1] spectrogram = np.zeros((f0_length, option.fft_size/2+1))
     cdef np.intp_t[:] tmp = np.zeros(f0_length, dtype=np.intp)
     cdef double **cpp_spectrogram = <double**> (<void*> &tmp[0])
     cdef np.intp_t i
@@ -156,22 +286,60 @@ def cheaptrick(
     return np.array(spectrogram, dtype=np.float64)
 
 
-def d4c(
-    np.ndarray[double, ndim=1, mode="c"] x not None, 
-    np.ndarray[double, ndim=1, mode="c"] f0 not None,
-    np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
-    int fs):
-    ''' Aperiodicity Estimation '''
+def d4c(np.ndarray[double, ndim=1, mode="c"] x not None, 
+        np.ndarray[double, ndim=1, mode="c"] f0 not None,
+        np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
+        int fs,
+        threshold=0.85, fft_size=None):
+    """D4C aperiodicity estimation algorithm.
+
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    f0 : ndarray
+        Input F0 contour.
+    temporal_positions : ndarray
+        Temporal positions of each frame.
+    fs : int
+        Sample rate of input signal in Hz.
+    q1 : float
+        Spectral recovery parameter.
+        Default: -0.15 (this value was tuned and normally does not need adjustment)
+    threshold : float
+        Threshold for aperiodicity-based voiced/unvoiced decision, in range 0 to 1.
+        If a value of 0 is used, voiced frames will be kept voiced. If a value > 0 is 
+        used some voiced frames can be considered unvoiced by setting their aperiodicity 
+        to 1 (thus synthesizing them with white noise). Using `threshold=0` will result 
+        in the behavior of older versions of D4C. The current default of 0.85 is meant 
+        to be used in combination with the Harvest F0 estimator, which was designed to have 
+        a high voiced/unvoiced threshold (i.e. most frames will be considered voiced).
+        Default: 0.85
+    fft_size : int, None
+        FFT size to be used. When `None` (default) is used, the FFT size is computed 
+        automatically as a function of the given input sample rate and the default F0 floor. 
+        When a specific FFT size is specified, it should generally match the FFT size used 
+        to compute the spectral envelope (i.e. `ftt_size=sp.shape[1]`) to be able to resynthesize.
+        Default: None
+
+    Returns
+    -------
+    spectrogram : ndarray
+        Spectral envelope.
+    """
     cdef int x_length = <int>len(x)
     cdef int f0_length = <int>len(f0)
-    cdef CheapTrickOption opt
-    InitializeCheapTrickOption(fs, &opt)
-    cdef int fft_size = GetFFTSizeForCheapTrick(fs, &opt)
+    cdef int fft_size0
+    if fft_size is None:
+        fft_size0 = get_cheaptrick_fft_size(fs, default_f0_floor)
+    else:
+        fft_size0 = fft_size
 
     cdef D4COption option
     InitializeD4COption(&option)
+    option.threshold = threshold
 
-    cdef double[:,::1] aperiodicity = np.zeros((f0_length, fft_size/2+1))
+    cdef double[:,::1] aperiodicity = np.zeros((f0_length, fft_size0/2+1))
     cdef np.intp_t[:] tmp = np.zeros(f0_length, dtype=np.intp)
     cdef double **cpp_aperiodicity = <double**> (<void*> &tmp[0])
     cdef np.intp_t i
@@ -179,46 +347,87 @@ def d4c(
         cpp_aperiodicity[i] = &aperiodicity[i, 0]
 
     D4C(&x[0], x_length, fs, &temporal_positions[0],
-        &f0[0], f0_length, fft_size, &option,
+        &f0[0], f0_length, fft_size0, &option,
         cpp_aperiodicity) 
     return np.array(aperiodicity, dtype=np.float64)
 
 
-def synthesize(
-    np.ndarray[double, ndim=1, mode="c"] f0 not None,
-    np.ndarray[double, ndim=2, mode="c"] np_spectrogram not None,
-    np.ndarray[double, ndim=2, mode="c"] np_aperiodicity not None,
-    int fs,
-    double frame_period):
-    ''' Synthesizer '''
+def synthesize(np.ndarray[double, ndim=1, mode="c"] f0 not None,
+               np.ndarray[double, ndim=2, mode="c"] spectrogram not None,
+               np.ndarray[double, ndim=2, mode="c"] aperiodicity not None,
+               int fs,
+               double frame_period=default_frame_period):
+    """WORLD synthesis from parametric representation.
+
+    Parameters
+    ----------
+    f0 : ndarray
+        Input F0 contour.
+    spectrogram : ndarray
+        Spectral envelope.
+    aperiodicity : ndarray
+        Aperodicity envelope.
+    fs : int
+        Sample rate of input signal in Hz.        
+    frame_period : float
+        Period between consecutive frames in milliseconds.
+        Default: 5.0
+
+    Returns
+    -------
+    y : ndarray
+        Output waveform signal.
+    """
     cdef int f0_length = <int>len(f0)
     y_length = int(f0_length * frame_period * fs / 1000)
-    # cdef int fft_size = GetFFTSizeForCheapTrick(fs)
-    cdef int fft_size = (<int>np_spectrogram.shape[1] - 1)*2
+    cdef int fft_size = (<int>spectrogram.shape[1] - 1)*2
     cdef np.ndarray[double, ndim=1, mode="c"] y = \
         np.zeros(y_length, dtype = np.dtype('float64'))
 
-    cdef double[:,::1] spectrogram = np_spectrogram
-    cdef double[:,::1] aperiodicity = np_aperiodicity
+    cdef double[:,::1] spectrogram0 = spectrogram
+    cdef double[:,::1] aperiodicity0 = aperiodicity
     cdef np.intp_t[:] tmp = np.zeros(f0_length, dtype=np.intp)
     cdef np.intp_t[:] tmp2 = np.zeros(f0_length, dtype=np.intp)
     cdef double **cpp_spectrogram = <double**> (<void*> &tmp[0])
     cdef double **cpp_aperiodicity = <double**> (<void*> &tmp2[0])
     cdef np.intp_t i
     for i in range(f0_length):
-        cpp_spectrogram[i] = &spectrogram[i,0]
-        cpp_aperiodicity[i] = &aperiodicity[i,0]
+        cpp_spectrogram[i] = &spectrogram0[i,0]
+        cpp_aperiodicity[i] = &aperiodicity0[i,0]
 
     Synthesis(&f0[0], f0_length, cpp_spectrogram, 
         cpp_aperiodicity, fft_size, frame_period, fs, y_length, &y[0])
     return y
 
 
-def wav2world(x, fs, pyDioOpt=None):
-    if pyDioOpt is None:
-        pyDioOpt = pyDioOption()
-    _f0, t = dio(x, fs, pyDioOpt)
+def wav2world(x, fs, frame_period=default_frame_period):
+    """Convenience function to do all WORLD analysis steps in a single call.
+
+    In this case only `frame_period` can be configured and other parameters 
+    are fixed to their defaults. Likewise, F0 estimation is fixed to 
+    DIO plus StoneMask refinement.
+
+    Parameters
+    ----------
+    x : ndarray
+        Input waveform signal.
+    fs : int
+        Sample rate of input signal in Hz.
+    frame_period : float
+        Period between consecutive frames in milliseconds.
+        Default: 5.0
+
+    Returns
+    -------
+    f0 : ndarray
+        F0 contour.
+    sp : ndarray
+        Spectral envelope.
+    ap : ndarray
+        Aperiodicity.
+    """
+    _f0, t = dio(x, fs, frame_period=frame_period)
     f0 = stonemask(x, _f0, t, fs)
     sp = cheaptrick(x, f0, t, fs)
     ap = d4c(x, f0, t, fs)
-    return f0, sp, ap, pyDioOpt
+    return f0, sp, ap

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,4 @@ ext_modules = [
 setup(name="pyworld",
 	ext_modules=ext_modules,
 	cmdclass={'build_ext': build_ext},
-    version='0.1.2')
+    version='0.2')

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ ext_modules = [
         	os.path.join(os.getcwd(), 'src')],
         sources=["pyworld.pyx", 
         	"src/synthesis.cpp", "src/cheaptrick.cpp", "src/common.cpp", 
-        	"src/d4c.cpp", "src/dio.cpp", "src/fft.cpp", "src/matlabfunctions.cpp",
+        	"src/d4c.cpp", "src/dio.cpp", "src/harvest.cpp", "src/fft.cpp", "src/matlabfunctions.cpp",
         	"src/stonemask.cpp", "src/synthesisrealtime.cpp"],
         language="c++")]
 
 setup(name="pyworld",
 	ext_modules=ext_modules,
 	cmdclass={'build_ext': build_ext},
-    version='0.1.1')
+    version='0.1.2')


### PR DESCRIPTION
This PR contains two main changes
- Synchronize with latest C WORLD API, including support for the new Harvest F0 estimator
- Changed API to allow control of all WORLD options and docstrings

Unfortunately the second change breaks backward compatibility of pyworld, but I think being able to change all options is worth it (e.g. I cannot get the results I want without modifying D4C's threshold option in latest WORLD).

Instead of having a bunch of `XyzOption` classes in Python, I decided to add all options as arguments-with-defaults to the functions. The disadvantage of this approach is that the default values used in the wrapper and those in C++ WORLD could go out of sync. On the other hand it avoids a lot of classes, is more "Pythonic" (IMHO), and allows you to easily see which default option values will be used without diving into the C++ code or checking them at run-time.