### PR TITLE
A couple of cleanup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,192 @@
 test/
-build/
-World/
-src/
 *.cpp
-*.so
 *.pyd
-*.egg-info
+
+# Created by https://www.gitignore.io
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+### IPythonNotebook ###
+# Temporary data
+.ipynb_checkpoints/
+
+
+### SublimeText ###
+# cache files for sublime text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# workspace files are user-specific
+*.sublime-workspace
+
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project
+
+# sftp configuration file
+sftp-config.json
+
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+
+
+### Vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+
+### C++ ###
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/World"]
+	path = lib/World
+	url = https://github.com/mmorise/World

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: 
+language:
   - python
 
 python:
@@ -11,8 +11,7 @@ before_install:
 install:
   - pip install -U pip
   - pip install -r requirements.txt
-  - bash download_vocoder.sh
-  - python setup.py build_ext --inplace
+  - pip install -e .
 
-script: 
+script:
   - python demo.py

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ World Vocoder parameterizes speech into three components:
 
 It can also resynthesize speech using these features (see examples below).
 
-For more information, please visit [Morise's World repository](https://github.com/mmorise/World) 
+For more information, please visit [Morise's World repository](https://github.com/mmorise/World)
 and the [official website of World Vocoder](http://ml.cs.yamanashi.ac.jp/world/english/)
 
 
@@ -44,13 +44,12 @@ f0, sp, ap = pw.wav2world(x, fs)
 ```bash
 git clone https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder.git
 cd Python-Wrapper-for-World-Vocoder
+git submodule update --init
 pip install -U pip
 pip install -r requirements.txt
-bash download_vocoder.sh
 python setup.py install
 ```
 It will automatically `git clone` Morise's World Vocoder (C++ version).<br/>
-Alternatively you can clone or download the World repository manually and copy its "src" directory to this repositories directory.<br/>
 As for installation mode (the last line), you can choose from the following options.
 
 
@@ -116,7 +115,7 @@ to see if you get results in `test/` direcotry.
      - scipy.io.wavfile.write
 
 ## TODO List
-  
+
 - [ ] Realtime synthesizer
 
 ## Acknowledgement

--- a/download_vocoder.sh
+++ b/download_vocoder.sh
@@ -1,2 +1,0 @@
-git clone https://github.com/mmorise/World
-mv World/src .

--- a/pyworld/__init__.py
+++ b/pyworld/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import division, print_function, absolute_import
+
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('pyworld').version
+
+from .pyworld import *

--- a/pyworld/pyworld.pyx
+++ b/pyworld/pyworld.pyx
@@ -1,6 +1,4 @@
 import cython
-from libc.stdlib cimport free
-from cpython cimport PyObject, Py_INCREF, array
 
 import numpy as np
 cimport numpy as np

--- a/pyworld/pyworld.pyx
+++ b/pyworld/pyworld.pyx
@@ -7,15 +7,15 @@ cimport numpy as np
 np.import_array()
 
 
-cdef extern from "src/world/synthesis.h":
-    void Synthesis(const double *f0, 
+cdef extern from "world/synthesis.h":
+    void Synthesis(const double *f0,
         int f0_length, const double * const *spectrogram,
-        const double * const *aperiodicity, 
-        int fft_size, double frame_period, 
+        const double * const *aperiodicity,
+        int fft_size, double frame_period,
         int fs, int y_length, double *y)
 
-    
-cdef extern from "src/world/cheaptrick.h":
+
+cdef extern from "world/cheaptrick.h":
     ctypedef struct CheapTrickOption:
         double q1
         double f0_floor
@@ -28,7 +28,7 @@ cdef extern from "src/world/cheaptrick.h":
         double **spectrogram)
 
 
-cdef extern from "src/world/dio.h":
+cdef extern from "world/dio.h":
     ctypedef struct DioOption:
         double f0_floor
         double f0_ceil
@@ -43,31 +43,31 @@ cdef extern from "src/world/dio.h":
         double *temporal_positions, double *f0)
 
 
-cdef extern from "src/world/harvest.h":
+cdef extern from "world/harvest.h":
     ctypedef struct HarvestOption:
         double f0_floor
         double f0_ceil
         double frame_period
 
-    void InitializeHarvestOption(HarvestOption *option)    
+    void InitializeHarvestOption(HarvestOption *option)
     int GetSamplesForHarvest(int fs, int x_length, double frame_period)
     void Harvest(const double *x, int x_length, int fs, const HarvestOption *option,
         double *temporal_positions, double *f0)
-        
-        
-cdef extern from "src/world/d4c.h":
+
+
+cdef extern from "world/d4c.h":
     ctypedef struct D4COption:
         double threshold
-    
+
     void InitializeD4COption(D4COption *option)
     void D4C(const double *x, int x_length, int fs, const double *temporal_positions,
         const double *f0, int f0_length, int fft_size, const D4COption *option,
-        double **aperiodicity) 
+        double **aperiodicity)
 
 
-cdef extern from "src/world/stonemask.h":
-    void StoneMask(const double *x, int x_length, int fs, 
-        const double *temporal_positions, const double *f0, int f0_length, 
+cdef extern from "world/stonemask.h":
+    void StoneMask(const double *x, int x_length, int fs,
+        const double *temporal_positions, const double *f0, int f0_length,
         double *refined_f0)
 
 
@@ -75,9 +75,9 @@ default_frame_period = 5.0
 default_f0_floor = 71.0
 default_f0_ceil = 800.0
 
-def dio(np.ndarray[double, ndim=1, mode="c"] x not None, int fs, 
-        f0_floor=default_f0_floor, f0_ceil=default_f0_ceil, 
-        channels_in_octave=2.0, frame_period=default_frame_period, 
+def dio(np.ndarray[double, ndim=1, mode="c"] x not None, int fs,
+        f0_floor=default_f0_floor, f0_ceil=default_f0_ceil,
+        channels_in_octave=2.0, frame_period=default_frame_period,
         speed=1, allowed_range=0.1):
     """DIO F0 extraction algorithm.
 
@@ -100,14 +100,14 @@ def dio(np.ndarray[double, ndim=1, mode="c"] x not None, int fs,
         Period between consecutive frames in milliseconds.
         Default: 5.0
     speed : int
-        The F0 estimator may downsample the input signal using this integer factor 
+        The F0 estimator may downsample the input signal using this integer factor
         (range [1;12]). The algorithm will then operate on a signal at fs/speed Hz
-        to reduce computational complexity, but high values may negatively impact 
+        to reduce computational complexity, but high values may negatively impact
         accuracy.
         Default: 1 (no downsampling)
     allowed_range : float
-        Threshold for voiced/unvoiced decision. Can be any value >= 0, but 0.02 to 0.2 
-        is a reasonable range. Lower values will cause more frames to be considered 
+        Threshold for voiced/unvoiced decision. Can be any value >= 0, but 0.02 to 0.2
+        is a reasonable range. Lower values will cause more frames to be considered
         unvoiced (in the extreme case of `threshold=0`, almost all frames will be unvoiced).
         Default: 0.1
 
@@ -135,8 +135,8 @@ def dio(np.ndarray[double, ndim=1, mode="c"] x not None, int fs,
     return f0, temporal_positions
 
 
-def harvest(np.ndarray[double, ndim=1, mode="c"] x not None, int fs, 
-            f0_floor=default_f0_floor, f0_ceil=default_f0_ceil, 
+def harvest(np.ndarray[double, ndim=1, mode="c"] x not None, int fs,
+            f0_floor=default_f0_floor, f0_ceil=default_f0_ceil,
             frame_period=default_frame_period):
     """Harvest F0 extraction algorithm.
 
@@ -176,11 +176,11 @@ def harvest(np.ndarray[double, ndim=1, mode="c"] x not None, int fs,
         np.zeros(f0_length, dtype = np.dtype('float64'))
     Harvest(&x[0], x_length, fs, &option, &temporal_positions[0], &f0[0])
     return f0, temporal_positions
-    
-    
-def stonemask(np.ndarray[double, ndim=1, mode="c"] x not None, 
-              np.ndarray[double, ndim=1, mode="c"] f0 not None, 
-              np.ndarray[double, ndim=1, mode="c"] temporal_positions not None, 
+
+
+def stonemask(np.ndarray[double, ndim=1, mode="c"] x not None,
+              np.ndarray[double, ndim=1, mode="c"] f0 not None,
+              np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
               int fs):
     """StoneMask F0 refinement algorithm.
 
@@ -217,7 +217,7 @@ def get_cheaptrick_fft_size(fs, f0_floor=default_f0_floor):
     fs : int
         Sample rate of input signal in Hz.
     f0_floor : float
-        Lower F0 limit in Hz. The required FFT size is a direct 
+        Lower F0 limit in Hz. The required FFT size is a direct
         consequence of the F0 floor used.
         Default: 71.0
 
@@ -231,7 +231,7 @@ def get_cheaptrick_fft_size(fs, f0_floor=default_f0_floor):
     cdef int fft_size = GetFFTSizeForCheapTrick(fs, &option)
     return fft_size
 
-def cheaptrick(np.ndarray[double, ndim=1, mode="c"] x not None, 
+def cheaptrick(np.ndarray[double, ndim=1, mode="c"] x not None,
                np.ndarray[double, ndim=1, mode="c"] f0 not None,
                np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
                int fs,
@@ -255,8 +255,8 @@ def cheaptrick(np.ndarray[double, ndim=1, mode="c"] x not None,
         Lower F0 limit in Hz. Not used in case `fft_size` is specified.
         Default: 71.0
     fft_size : int, None
-        FFT size to be used. When `None` (default) is used, the FFT size is computed 
-        automatically as a function of the given input sample rate and F0 floor. 
+        FFT size to be used. When `None` (default) is used, the FFT size is computed
+        automatically as a function of the given input sample rate and F0 floor.
         When a specific FFT size is specified, the given `f0_floor` parameter is ignored.
         Default: None
 
@@ -289,7 +289,7 @@ def cheaptrick(np.ndarray[double, ndim=1, mode="c"] x not None,
     return np.array(spectrogram, dtype=np.float64)
 
 
-def d4c(np.ndarray[double, ndim=1, mode="c"] x not None, 
+def d4c(np.ndarray[double, ndim=1, mode="c"] x not None,
         np.ndarray[double, ndim=1, mode="c"] f0 not None,
         np.ndarray[double, ndim=1, mode="c"] temporal_positions not None,
         int fs,
@@ -311,17 +311,17 @@ def d4c(np.ndarray[double, ndim=1, mode="c"] x not None,
         Default: -0.15 (this value was tuned and normally does not need adjustment)
     threshold : float
         Threshold for aperiodicity-based voiced/unvoiced decision, in range 0 to 1.
-        If a value of 0 is used, voiced frames will be kept voiced. If a value > 0 is 
-        used some voiced frames can be considered unvoiced by setting their aperiodicity 
-        to 1 (thus synthesizing them with white noise). Using `threshold=0` will result 
-        in the behavior of older versions of D4C. The current default of 0.85 is meant 
-        to be used in combination with the Harvest F0 estimator, which was designed to have 
+        If a value of 0 is used, voiced frames will be kept voiced. If a value > 0 is
+        used some voiced frames can be considered unvoiced by setting their aperiodicity
+        to 1 (thus synthesizing them with white noise). Using `threshold=0` will result
+        in the behavior of older versions of D4C. The current default of 0.85 is meant
+        to be used in combination with the Harvest F0 estimator, which was designed to have
         a high voiced/unvoiced threshold (i.e. most frames will be considered voiced).
         Default: 0.85
     fft_size : int, None
-        FFT size to be used. When `None` (default) is used, the FFT size is computed 
-        automatically as a function of the given input sample rate and the default F0 floor. 
-        When a specific FFT size is specified, it should generally match the FFT size used 
+        FFT size to be used. When `None` (default) is used, the FFT size is computed
+        automatically as a function of the given input sample rate and the default F0 floor.
+        When a specific FFT size is specified, it should generally match the FFT size used
         to compute the spectral envelope (i.e. `ftt_size=sp.shape[1]`) to be able to resynthesize.
         Default: None
 
@@ -351,7 +351,7 @@ def d4c(np.ndarray[double, ndim=1, mode="c"] x not None,
 
     D4C(&x[0], x_length, fs, &temporal_positions[0],
         &f0[0], f0_length, fft_size0, &option,
-        cpp_aperiodicity) 
+        cpp_aperiodicity)
     return np.array(aperiodicity, dtype=np.float64)
 
 
@@ -371,7 +371,7 @@ def synthesize(np.ndarray[double, ndim=1, mode="c"] f0 not None,
     aperiodicity : ndarray
         Aperodicity envelope.
     fs : int
-        Sample rate of input signal in Hz.        
+        Sample rate of input signal in Hz.
     frame_period : float
         Period between consecutive frames in milliseconds.
         Default: 5.0
@@ -398,7 +398,7 @@ def synthesize(np.ndarray[double, ndim=1, mode="c"] f0 not None,
         cpp_spectrogram[i] = &spectrogram0[i,0]
         cpp_aperiodicity[i] = &aperiodicity0[i,0]
 
-    Synthesis(&f0[0], f0_length, cpp_spectrogram, 
+    Synthesis(&f0[0], f0_length, cpp_spectrogram,
         cpp_aperiodicity, fft_size, frame_period, fs, y_length, &y[0])
     return y
 
@@ -406,8 +406,8 @@ def synthesize(np.ndarray[double, ndim=1, mode="c"] f0 not None,
 def wav2world(x, fs, frame_period=default_frame_period):
     """Convenience function to do all WORLD analysis steps in a single call.
 
-    In this case only `frame_period` can be configured and other parameters 
-    are fixed to their defaults. Likewise, F0 estimation is fixed to 
+    In this case only `frame_period` can be configured and other parameters
+    are fixed to their defaults. Likewise, F0 estimation is fixed to
     DIO plus StoneMask refinement.
 
     Parameters

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,59 @@
+from __future__ import with_statement, print_function, absolute_import
+
+from setuptools import setup, find_packages, Extension
+from distutils.version import LooseVersion
+
+import numpy as np
 import os
-import numpy
-from setuptools import setup, Extension
-from Cython.Distutils import build_ext
+from glob import glob
+from os.path import join
+
+
+# This can be loosen probably, though it's fine I think
+min_cython_ver = '0.24.0'
+try:
+    import Cython
+    ver = Cython.__version__
+    _CYTHON_INSTALLED = ver >= LooseVersion(min_cython_ver)
+except ImportError:
+    _CYTHON_INSTALLED = False
+
+try:
+    if not _CYTHON_INSTALLED:
+        raise ImportError('No supported version of Cython installed.')
+    from Cython.Distutils import build_ext
+    cython = True
+except ImportError:
+    cython = False
+
+if cython:
+    ext = '.pyx'
+    cmdclass = {'build_ext': build_ext}
+else:
+    ext = '.cpp'
+    cmdclass = {}
+    if not os.path.exists(join("pyworld", "pyworld" + ext)):
+        raise RuntimeError("Cython is required to generate C++ wrapper")
+
+world_src_top = join("lib", "World", "src")
+world_sources = glob(join(world_src_top, "*.cpp"))
 
 ext_modules = [
     Extension(
-        name="pyworld",
-        include_dirs=[numpy.get_include(),
-        	os.path.join(os.getcwd(), 'src')],
-        sources=["pyworld.pyx", 
-        	"src/synthesis.cpp", "src/cheaptrick.cpp", "src/common.cpp", 
-        	"src/d4c.cpp", "src/dio.cpp", "src/harvest.cpp", "src/fft.cpp", "src/matlabfunctions.cpp",
-        	"src/stonemask.cpp", "src/synthesisrealtime.cpp"],
+        name="pyworld.pyworld",
+        include_dirs=[np.get_include(), world_src_top],
+        sources=[join("pyworld", "pyworld.pyx")] + world_sources,
         language="c++")]
 
 setup(name="pyworld",
-	ext_modules=ext_modules,
-	cmdclass={'build_ext': build_ext},
-    version='0.2')
+      ext_modules=ext_modules,
+      cmdclass=cmdclass,
+      version='0.2',
+      packages=find_packages(),
+      install_requires=[
+          'numpy',
+      ],
+      extras_require={
+          'test': ['nose'],
+          'develop': ['cython >= ' + min_cython_ver],
+      })


### PR DESCRIPTION
I have a couple of cleanup fixes that I think it would be helpful.

- Specify explicit version of world dependency (added as submodule instead of downloading the latest one). Depending on master branch might break unexpectedly.
- Move pyworld.pyx into pyworld directory. I believe that having ${package_name} directory in the repository is more python-like than placing the package into the top-level directory.
- Improve setup.py so that users can install the package from pre-generated C++ wrapper even if Cython isn't available (would be helpful once we release the package source on pypi)
- Make .gitignore to be robust.

Now that installation will become one line (if you already have cython): 

```
pip install git+https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder
# for now
# pip install git+https://github.com/r9y9/Python-Wrapper-for-World-Vocoder@cleanup
```