### PR TITLE
Support building wheels for Windows by AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+environment:
+  matrix:
+    - PYTHON_ROOT: C:\Python36-x64
+      PYTHON_VERSION: 3.6
+    - PYTHON_ROOT: C:\Python27-x64
+      PYTHON_VERSION: 2.7
+platform: x64
+init:
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      Write-Output "*** Python $env:PYTHON_VERSION ***"
+      $env:Path += ";$env:PYTHON_ROOT;$env:PYTHON_ROOT\Scripts"
+install:
+  - ps: $ErrorActionPreference = "Stop"
+  - ps: Write-Output "Cloning submodules..."
+  - ps: git submodule init
+  - ps: git submodule update
+  - ps: |
+      Write-Output "Updating pip..."
+      pip install -U pip
+  - ps: |
+      Write-Output "Installing wheel..."
+      pip install wheel
+  - ps: |
+      Write-Output "Installing requirements..."
+      pip install -r requirements.txt
+  - ps: |
+      Write-Output "Installing PyWorld..."
+      python setup.py install
+      
+test_script:
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      Set-Location "$env:APPVEYOR_BUILD_FOLDER\demo"
+      python demo.py
+
+after_test:
+  - ps: |
+        python setup.py bdist_wheel
+
+artifacts:
+  - path: dist\*


### PR DESCRIPTION
I tried to build wheels for Windows so that Windows users can install PyWorld without Visual Studio, but `git submodule init` fails in AppVeyor and am dying for help.  I succeeded in building wheel in my Windows environment (Python 3.6 x64 with Anaconda).

Status:
https://ci.appveyor.com/project/tats-u/python-wrapper-for-world-vocoder