### PR TITLE
Succeeded in building wheels for Py3.6 in Windows with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ test_script:
       $ErrorActionPreference = "Stop"
       Set-Location "$env:APPVEYOR_BUILD_FOLDER\demo"
       python demo.py
+      Set-Location "$env:APPVEYOR_BUILD_FOLDER"
 
 after_test:
   - python setup.py bdist_wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,13 @@
 environment:
   matrix:
-    - PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda
-
-    - PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      MINICONDA: C:\Miniconda-x64
-
-    - PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda3
-
     - PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
       
+    - PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+
 # platform: x64
 
 init:


### PR DESCRIPTION
32bit result: https://ci.appveyor.com/project/tats-u/python-wrapper-for-world-vocoder/build/job/21gxwvwekd30jqpt
64bit result: https://ci.appveyor.com/project/tats-u/python-wrapper-for-world-vocoder/build/job/t49shnpdns6jlfpr

But I don't know why builds in Py2.7 fail.

32bit: https://ci.appveyor.com/project/tats-u/python-wrapper-for-world-vocoder/build/job/ik36v19i8ge49ghr
64bit: https://ci.appveyor.com/project/tats-u/python-wrapper-for-world-vocoder/build/job/5xyyirro5b9llt1x