### PR TITLE
Add matplotlib to conda install in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda update -q conda
   - conda config --add channels pypi
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy cython wheel"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy cython wheel matplotlib"
   - activate test-environment
   - python -m pip install --no-cache-dir -U pip
   - ps: |


### PR DESCRIPTION
AppVeyor seems to fail in installing matplotlib from pip.
I made it installed from conda.