### PR TITLE
Add pyproject.toml to specify build-time requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = [
     "wheel",
     "setuptools",
     "cython>=0.24.0",
-    "numpy",
+    "numpy<v1.20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "cython>=0.24.0",
+    "numpy",
+]

--- a/setup.py
+++ b/setup.py
@@ -15,20 +15,13 @@ from distutils.version import LooseVersion
 import os
 from glob import glob
 from os.path import join
+import numpy
 
-from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.command.build_ext import build_ext
 
 
 DOCLINES = __doc__.split('\n')
 _VERSION = '0.2.12'
-
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
 
 world_src_top = join("lib", "World", "src")
 world_sources = glob(join(world_src_top, "*.cpp"))
@@ -36,7 +29,7 @@ world_sources = glob(join(world_src_top, "*.cpp"))
 ext_modules = [
     Extension(
         name="pyworld.pyworld",
-        include_dirs=[world_src_top],
+        include_dirs=[world_src_top, numpy.get_include()],
         sources=[join("pyworld", "pyworld.pyx")] + world_sources,
         language="c++")]
 


### PR DESCRIPTION
With this, I believe numpy import hack in the setup.py is no longer necessary and it may fix installation issues like https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/issues/63