### PR TITLE
Updated world vocoder, bumped pyworld to v 0.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.build_ext import build_ext
 
 
 DOCLINES = __doc__.split('\n')
-_VERSION = '0.3.1'
+_VERSION = '0.3.2'
 
 world_src_top = join("lib", "World", "src")
 world_sources = glob(join(world_src_top, "*.cpp"))


### PR DESCRIPTION
Tested this thoroughly, as i use Pyworld in the RHVoice project.
I see that it fixes 
#58 
This pull request updates the pyworld to be synced from the latest version from february this year.