### PR TITLE
Fixes dash-seperator deprecation issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Closes #81 

## 📑 Description
Usage of dash-separated deprecated in the latest version of pip install.
Python 3.9.6
pip 22.3.1


- [ ] Not Completed
- [x] Completed


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

