### PR TITLE
Update cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "wheel",
     "setuptools",
-    "cython",
+    "cython==0.29.36",
     "numpy",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 matplotlib
 argparse
-cython
+cython==0.29.36
 pysoundfile


### PR DESCRIPTION
There is an error raising when installing pyworld through pip since July 17th, the error occurs from the newly released cython, restricting the cython version can help solve the error.