### PR TITLE
ENH: support Numpy2 and legacy Numpy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ test_script:
       Set-Location "$env:APPVEYOR_BUILD_FOLDER"
 
 after_test:
-  - python setup.py bdist_wheel
+  - pip wheel --wheel-dir=.\dist --no-deps .
 
 artifacts:
   - path: dist\*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools",
-    "numpy",
+    "numpy>=2; python_version>='3.9'",
+    "oldest-supported-numpy; python_version<'3.9'",
     "cython",
 ]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 matplotlib
-argparse
-cython
-pysoundfile
+argparse; python_version<"3.5"
+soundfile

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
-from __future__ import with_statement, print_function, absolute_import
-
-from setuptools import setup, find_packages, Extension
-from distutils.version import LooseVersion
+from __future__ import absolute_import, print_function, with_statement
 
 import sys
 from glob import glob
 from os.path import join
-import numpy
 
+import numpy
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 
@@ -34,13 +32,7 @@ setup(
     cmdclass={'build_ext': build_ext},
     version=_VERSION,
     packages=find_packages(),
-    setup_requires=[
-        'numpy',
-    ],
-    install_requires=[
-        'numpy',
-        'cython>=0.24',
-    ],
+    install_requires=['numpy'],
     extras_require={
         'test': ['nose'],
         'sdist': ['numpy', 'cython>=0.24'],


### PR DESCRIPTION
Need to rebuild to support Numpy2.
This PR will ensure that.
ref: https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency

We will also make improvements to allow older Numpy versions as much as possible for Python < 3.9.
ref: https://numpy.org/doc/1.24/dev/depending_on_numpy.html#build-time-dependency
ref: https://github.com/scipy/oldest-supported-numpy/

Finally, we fixed some outdated build settings.