### PR TITLE
MNT: migrate from pkg_resources to importlib_metadata

### DIFF
--- a/pyworld/__init__.py
+++ b/pyworld/__init__.py
@@ -9,9 +9,13 @@ For more information, see https://github.com/JeremyCCHsu/Python-Wrapper-for-Worl
 """
 
 from __future__ import division, print_function, absolute_import
+import sys
 
-import pkg_resources
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
-__version__ = pkg_resources.get_distribution('pyworld').version
+__version__ = version('pyworld')
 
 from .pyworld import *

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ setup(
     cmdclass={'build_ext': build_ext},
     version=_VERSION,
     packages=find_packages(),
-    install_requires=['numpy'],
+    install_requires=[
+        'numpy',
+        'importlib-metadata; python_version<"3.8"',
+    ],
     extras_require={
         'test': ['nose'],
         'sdist': ['numpy', 'cython>=0.24'],


### PR DESCRIPTION
Replace pkg_resources with importlib-metadata.
This removes the implicit setuptools dependency.