### PR TITLE
ENH: release global interpreter lock

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ test_script:
       Set-Location "$env:APPVEYOR_BUILD_FOLDER"
 
 after_test:
-  - python setup.py bdist_wheel
+  - pip wheel --wheel-dir=.\dist --no-deps .
 
 artifacts:
   - path: dist\*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 matplotlib
-argparse
-cython
-pysoundfile
+argparse; python_version<"3.5"
+soundfile


### PR DESCRIPTION
Release GIL when execute `Synthesis` `CheapTrick` `Dio` `Harvest` `D4C` `StoneMask`.

Update World.
NOTE: Updating the world is necessary to prevent a data race in `randn()`.

Other small optimizations.