### PR TITLE
FIX: Fix build failure issue with Python3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,6 @@ requires = [
     "numpy>=2; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",
     "cython",
+    "cython<3.1.0; python_version<'3.9'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Build fails with Python 3.8.
There seems to be a problem with the combination of Cython >= 3.1.0 and numpy < 1.19.

This fix works around the issue by changing Python 3.8 to build with Cython < 3.1.0.