### PR TITLE
removed (hidden) dependency on deprecated `pkg_resources` package

### DIFF
--- a/pyworld/__init__.py
+++ b/pyworld/__init__.py
@@ -10,8 +10,8 @@ For more information, see https://github.com/JeremyCCHsu/Python-Wrapper-for-Worl
 
 from __future__ import division, print_function, absolute_import
 
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.get_distribution('pyworld').version
+__version__ = version("pyworld")
 
 from .pyworld import *


### PR DESCRIPTION
There is a hidden external dependency on deprecated `pkg_resources` package [^1] to retrieve the version info. This PR removes this dependency and replace it with the built-in `importlib` to get the version string.

[^1]: Deprecation Note: https://setuptools.pypa.io/en/latest/pkg_resources.html